### PR TITLE
Fix Leaderboard nulls

### DIFF
--- a/src/components/Leaderboard.vue
+++ b/src/components/Leaderboard.vue
@@ -41,7 +41,7 @@ function msToElapsedString(totalms: number): string {
   <div className="content has-text-centered">
     <div className="block">
       <h2 className="title">{{ username }}&apos;s time:</h2>
-      <p className="subtitle">
+      <p className="subtitle" v-if="store.submittedRun">
         {{ msToElapsedString(store.submittedRun?.totalTimeMilliseconds) }}
       </p>
     </div>
@@ -59,7 +59,7 @@ function msToElapsedString(totalms: number): string {
           <tr
             v-for="(result, index) in store.topResults"
             :key="index"
-            :class="store.submittedRun.id === result.id ? 'is-selected' : ''"
+            :class="store.submittedRun?.id === result.id ? 'is-selected' : ''"
           >
             <th>{{ index + 1 }}</th>
             <td>{{ result.username }}</td>
@@ -82,7 +82,7 @@ function msToElapsedString(totalms: number): string {
           <tr
             v-for="(result, index) in store.userResults"
             :key="index"
-            :class="store.submittedRun.id === result.id ? 'is-selected' : ''"
+            :class="store.submittedRun?.id === result.id ? 'is-selected' : ''"
           >
             <th>{{ index + 1 }}</th>
             <td>{{ result.username }}</td>


### PR DESCRIPTION
Fix Leaderboard null errors in the Leaderboard. 

These errors occur when running `build:client`:

```
> vue-ts-template@1.0.0 build   
> vue-tsc --noEmit && vite build

src/components/Leaderboard.vue:45:30 - error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
  Type 'undefined' is not assignable to type 'number'.

45         {{ msToElapsedString(store.submittedRun?.totalTimeMilliseconds) }}
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/components/Leaderboard.vue:62:21 - error TS2531: Object is possibly 'null'.

62             :class="store.submittedRun.id === result.id ? 'is-selected' : ''"
                       ~~~~~~~~~~~~~~~~~~

src/components/Leaderboard.vue:85:21 - error TS2531: Object is possibly 'null'.

85             :class="store.submittedRun.id === result.id ? 'is-selected' : ''"
                       ~~~~~~~~~~~~~~~~~~


Found 3 errors in the same file, starting at: src/components/Leaderboard.vue:45
```